### PR TITLE
Remove ckeditor5 table fix

### DIFF
--- a/unity_common/css/claro.overrides.css
+++ b/unity_common/css/claro.overrides.css
@@ -1,8 +1,0 @@
-/* Overrides for Claro admin theme. */
-.entity-subqueue-slideshow-edit-form .js-form-item-items-add-more-new-item-target-id {
-  margin-top: 0;
-}
-/* Ensure that table borders shown in CKEditor 5 in Firefox */
-.ck .ck-content .table td {
-  position: static;
-}

--- a/unity_common/unity_common.libraries.yml
+++ b/unity_common/unity_common.libraries.yml
@@ -10,7 +10,3 @@ unity_common_validation.ife:
     js/unity-common-validation.ife.js: { weight: -1 }
   dependencies:
     - clientside_validation_jquery/cv.jquery.validate.ife
-unity_common_claro_fixes:
-  css:
-    theme:
-      css/claro.overrides.css: {}

--- a/unity_common/unity_common.module
+++ b/unity_common/unity_common.module
@@ -60,11 +60,6 @@ function unity_common_form_alter(&$form, FormStateInterface $form_state, $form_i
       $form['#attached']['library'][] = 'unity_common/unity_common_validation.ife';
     }
   }
-
-  // Add Claro fixes on entity queue page and also on all node edit forms.
-  if (($form['#id'] == 'entity-subqueue-slideshow-edit-form') || (preg_match('/-edit-form$/', $form['#id']))) {
-    $form['#attached']['library'][] = 'unity_common/unity_common_claro_fixes';
-  }
 }
 
 /**

--- a/unity_common/unity_common.module
+++ b/unity_common/unity_common.module
@@ -210,21 +210,3 @@ function unity_common_media_source_info_alter(array &$sources) {
 function unity_common_preprocess_book_navigation(&$variables) {
   $variables['#cache']['max-age'] = 0;
 }
-
-/**
- * Implements hook_editor_js_settings_alter().
- */
-function unity_common_editor_js_settings_alter(array &$settings) {
-  // Remove the 'merge cells' option from the CKEditor 5 table options menu.
-  foreach ($settings['editor']['formats'] as &$format) {
-    if (isset($format['editorSettings']['config']['table'])) {
-      foreach ($format['editorSettings']['config']['table']['contentToolbar'] as $idx => $option) {
-        // Check for 'mergeTableCells' option.
-        if ($option == 'mergeTableCells') {
-          // Remove this option and re-index array.
-          array_splice($format['editorSettings']['config']['table']['contentToolbar'], $idx, 1);
-        }
-      }
-    }
-  }
-}


### PR DESCRIPTION
Remove CKEditor 5 fixes from Unity modules as they would be better placed in Origins modules.

See also https://github.com/dof-dss/nicsdru_origins_modules/pull/301